### PR TITLE
Fixed demo project view styles

### DIFF
--- a/Demo/ShellControlsDemo/MainUnit.dfm
+++ b/Demo/ShellControlsDemo/MainUnit.dfm
@@ -222,13 +222,14 @@ object MainForm: TMainForm
           Height = 44
           Align = alClient
           Caption = 'View Style'
-          Columns = 4
+          Columns = 5
           ItemIndex = 0
           Items.Strings = (
             'Icon'
+            'SmallIcon'
             'List'
             'Report'
-            'SmallIcon')
+            'Tile')
           TabOrder = 1
           OnClick = ViewStyleClick
         end


### PR DESCRIPTION
My version of Delphi (12.0 community edition) has TViewStyle defined as follows:

`TViewStyle = (vsIcon, vsSmallIcon, vsList, vsReport, vsTile);`

The demo project was fixed accordingly, otherwise the cast `ShellListView.ViewStyle := TViewStyle(ViewStyle.ItemIndex);` would lead to a very wrong result